### PR TITLE
Match any version number in popolo filename

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,8 +4,10 @@ require 'open-uri'
 require 'erb'
 
 class FindPopoloFiles
+  POPOLO_FILE_REGEX = /ep-popolo-v(\d+\.)?(\d+\.)?\d+\.json$/
+
   def self.from(files)
-    files.find_all { |file| file[:filename].match(/ep-popolo-v1.0\.json$/) }
+    files.find_all { |file| file[:filename].match(POPOLO_FILE_REGEX) }
   end
 end
 

--- a/test/find_popolo_files_test.rb
+++ b/test/find_popolo_files_test.rb
@@ -9,4 +9,13 @@ describe FindPopoloFiles do
     popolo_files = FindPopoloFiles.from(files)
     assert_equal [{ filename: 'data/UK/Commons/ep-popolo-v1.0.json' }], popolo_files
   end
+
+  it 'matches any version of the popolo file' do
+    files = [
+      { filename: 'countries.json' },
+      { filename: 'data/UK/Commons/ep-popolo-v2.4.3.json' }
+    ]
+    popolo_files = FindPopoloFiles.from(files)
+    assert_equal [{ filename: 'data/UK/Commons/ep-popolo-v2.4.3.json' }], popolo_files
+  end
 end


### PR DESCRIPTION
Previously the regex only matched version 1.0, so when a new version
came out this would silently fail because the filename wouldn't be
matched. This change means we should catch new versions of the file. If
there's a problem with the format of the file then at least the program
will error noisily.
