### PR TITLE
Report on changes to additional names

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -42,6 +42,23 @@ class ComparePopolo
     }
   end
 
+  def people_additional_name_changes
+    all_names = ->(p) { 
+      other_names = p.other_names.map { |n| n[:name] } rescue []
+      (other_names | [ p.name ]).to_set
+    }
+    names_all_pre =  Hash[ before.persons.map { |p| [p.id, all_names.(p)] } ]
+    names_all_post = Hash[ after.persons.map  { |p| [p.id, all_names.(p)] } ]
+    in_both = names_all_pre.keys & names_all_post.keys
+    in_both.select { |id| names_all_pre[id] != names_all_post[id].to_set }.map { |id|
+      {
+        id: id,
+        removed: (names_all_pre[id] - names_all_post[id]).to_a,
+        added:   (names_all_post[id] - names_all_pre[id]).to_a,
+      }
+    }
+  end
+
   def people_added
     after.persons - before.persons
   end

--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -33,6 +33,16 @@ No people removed
 No name changes
 <% end %>
 
+### Additional Name Changes
+
+<% if file.people_additional_name_changes.any? %>
+<% file.people_additional_name_changes.each do |r| %>
+- `<%= r[:id] %>`: <% if r[:removed].any? %>Removed: <%= r[:removed].join(" ﹠ ") %>. <% end %><% if r[:added].any? %>Added: <%= r[:added].join(" ﹠ ") %>.<% end %>
+<% end %>
+<% else %>
+No name changes
+<% end %>
+
 ### Wikidata Changes
 
 <% if file.wikidata_links_changed.any? %>

--- a/test/new_names_test.rb
+++ b/test/new_names_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+describe ReviewChanges do
+  let(:before_after) do
+    [
+      {
+        before: {
+          persons: [
+            { id: '1',  name: 'Albert' },
+            { id: '10', name: 'Fred', other_names: [ { name: 'Freddy' } ]},
+            { id: '11', name: 'Tom', other_names: [ { name: 'Tommy' } ]},
+            { id: '12', name: 'Jack' },
+            { id: '13', name: 'Kate' },
+            { id: '14', name: 'Edward', other_names: [ { name: 'Ed' }, { name: 'Ted' }] },
+            { id: '15', name: 'Bob', other_names: [{ name: 'Bobby' }] },
+          ],
+        }.to_json,
+        after: {
+          persons: [
+            # No changes, no other names
+            { id: '1',  name: 'Albert' },
+            # No changes, with other names
+            { id: '10', name: 'Fred', other_names: [ { name: 'Freddy' } ]},
+            # Remove name
+            { id: '11', name: 'Tom' },
+            # Add name
+            { id: '12', name: 'Jack', other_names: [{ name: 'Jackie' }] },
+            # Add multiple names
+            { id: '13', name: 'Kate', other_names: [ { name: 'Katy' }, { name: 'Katie' }] },
+            # Change one name
+            { id: '14', name: 'Edward', other_names: [ { name: 'Ed' }, { name: 'Eddie' }] },
+            # Swap primary
+            { id: '15', name: 'Bobby', other_names: [{ name: 'Bob' }] },
+          ],
+        }.to_json,
+        path: 'foo/bar.json'
+      }
+    ]
+  end
+
+  subject { ReviewChanges.new(before_after) }
+
+  it 'renders the comment template' do
+    comment = subject.to_html.split(/^### /).find { |s| s.start_with? 'Additional Name Changes' }
+    assert comment.include?('- `11`: Removed: Tommy.')
+    assert comment.include?('- `12`: Added: Jackie.')
+    assert comment.include?('- `13`: Added: Katy ﹠ Katie.')
+    assert comment.include?('- `14`: Removed: Ted. Added: Eddie.')
+    refute comment.include?('- `1`')
+    refute comment.include?('- `10`')
+    refute comment.include?('- `15`')
+  end
+end


### PR DESCRIPTION
Previously we only reported on changes to a person's actual `name`
field. Now we should report if anything changes in their `other_names`
as well.
