### PR TITLE
Include primary name in Alternate Name report

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -29,15 +29,21 @@ class ComparePopolo
     @path = options[:path]
   end
 
+  def before_names
+    @name_hash_pre ||= Hash[ before.persons.map { |p| [p.id, p.name] } ]
+  end
+
+  def after_names
+    @name_hash_post ||= Hash[ after.persons.map { |p| [p.id, p.name] } ]
+  end
+
   def people_name_changes
-    name_hash_pre =  Hash[ before.persons.map { |p| [p.id, p.name] } ]
-    name_hash_post = Hash[ after.persons.map  { |p| [p.id, p.name] } ]
-    in_both = name_hash_pre.keys & name_hash_post.keys
-    in_both.select { |id| name_hash_pre[id].downcase != name_hash_post[id].downcase }.map { |id|
+    in_both = before_names.keys & after_names.keys
+    in_both.select { |id| before_names[id].downcase != after_names[id].downcase }.map { |id|
       {
         id: id,
-        was: name_hash_pre[id],
-        now: name_hash_post[id],
+        was: before_names[id],
+        now: after_names[id],
       }
     }
   end
@@ -50,9 +56,10 @@ class ComparePopolo
     names_all_pre =  Hash[ before.persons.map { |p| [p.id, all_names.(p)] } ]
     names_all_post = Hash[ after.persons.map  { |p| [p.id, all_names.(p)] } ]
     in_both = names_all_pre.keys & names_all_post.keys
-    in_both.select { |id| names_all_pre[id] != names_all_post[id].to_set }.map { |id|
+    in_both.select { |id| names_all_pre[id] != names_all_post[id] }.map { |id|
       {
         id: id,
+        name: before_names[id],
         removed: (names_all_pre[id] - names_all_post[id]).to_a,
         added:   (names_all_post[id] - names_all_pre[id]).to_a,
       }

--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -37,7 +37,7 @@ No name changes
 
 <% if file.people_additional_name_changes.any? %>
 <% file.people_additional_name_changes.each do |r| %>
-- `<%= r[:id] %>`: <% if r[:removed].any? %>Removed: <%= r[:removed].join(" ﹠ ") %>. <% end %><% if r[:added].any? %>Added: <%= r[:added].join(" ﹠ ") %>.<% end %>
+- `<%= r[:id] %>` (<%= r[:name] %>): <% if r[:removed].any? %>Removed: <%= r[:removed].join(" ﹠ ") %>. <% end %><% if r[:added].any? %>Added: <%= r[:added].join(" ﹠ ") %>.<% end %>
 <% end %>
 <% else %>
 No name changes

--- a/test/new_names_test.rb
+++ b/test/new_names_test.rb
@@ -42,10 +42,10 @@ describe ReviewChanges do
 
   it 'renders the comment template' do
     comment = subject.to_html.split(/^### /).find { |s| s.start_with? 'Additional Name Changes' }
-    assert comment.include?('- `11`: Removed: Tommy.')
-    assert comment.include?('- `12`: Added: Jackie.')
-    assert comment.include?('- `13`: Added: Katy ﹠ Katie.')
-    assert comment.include?('- `14`: Removed: Ted. Added: Eddie.')
+    assert comment.include?('- `11` (Tom): Removed: Tommy.')
+    assert comment.include?('- `12` (Jack): Added: Jackie.')
+    assert comment.include?('- `13` (Kate): Added: Katy ﹠ Katie.')
+    assert comment.include?('- `14` (Edward): Removed: Ted. Added: Eddie.')
     refute comment.include?('- `1`')
     refute comment.include?('- `10`')
     refute comment.include?('- `15`')


### PR DESCRIPTION
Changes that simply say:
`ed651195-2f16-4074-86d0-ba81c2581f36: Added: Keit` 
aren't really enough — we also need to see what their primary name is.
