### PR TITLE
auto-require everything in lib/

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,5 @@ Bundler.require
 
 require 'open-uri'
 require 'erb'
-require 'find_popolo_files'
-require 'compare_popolo'
-require 'review_changes'
-require 'pull_request_review'
+
+require_all 'lib'


### PR DESCRIPTION
By default 'lib' isn't in the LOAD_PATH, so these 'require's are
failing. Rather than twiddling that, or using 'require_relative', we
can use 'require_all', as we're already using that anyway.
