### PR TITLE
Report missing and removed terms in bot PR summary

### DIFF
--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -75,4 +75,26 @@ No organizations added
 No organizations removed
 <% end %>
 
+## Terms
+
+### Added
+
+<% if file.terms_added.any? %>
+<% file.terms_added.each do |term| %>
+- `<%= term.id %>` - <%= term.name %>
+<% end %>
+<% else %>
+No terms added
+<% end %>
+
+### Removed
+
+<% if file.terms_removed.any? %>
+<% file.terms_removed.each do |term| %>
+- `<%= term.id %>` - <%= term.name %>
+<% end %>
+<% else %>
+No terms removed
+<% end %>
+
 <% end %>

--- a/lib/compare_popolo.rb
+++ b/lib/compare_popolo.rb
@@ -44,4 +44,12 @@ class ComparePopolo
   def organizations_removed
     Report::Organizations.new(before, after).removed
   end
+
+  def terms_added
+    Report::Terms.new(before, after).added
+  end
+
+  def terms_removed
+    Report::Terms.new(before, after).removed
+  end
 end

--- a/lib/report/terms.rb
+++ b/lib/report/terms.rb
@@ -1,0 +1,17 @@
+class Report
+  class Terms < Base
+    def terms(events)
+      events.select do |event|
+        event if event.document[:classification] == 'legislative period'
+      end
+    end
+
+    def added
+      terms(after.events - before.events)
+    end
+
+    def removed
+      terms(before.events - after.events)
+    end
+  end
+end

--- a/test/compare_popolo_test.rb
+++ b/test/compare_popolo_test.rb
@@ -28,4 +28,16 @@ describe ComparePopolo do
   it 'returns the full popolo for removed organizations' do
     assert_equal [Everypolitician::Popolo::Organization.new(id: '88f2ef1f-f686-4496-a41c-98b6bb3ccaa7')], subject.organizations_removed
   end
+
+  it 'should return the full popolo for removed terms' do
+    assert_equal [Everypolitician::Popolo::Event.new(classification: 'legislative period',
+                                                     id:             'term/52',
+                                                     name:           '52nd Parliament of the United Kingdom'),], subject.terms_removed
+  end
+
+  it 'should return the full popolo for add terms' do
+    assert_equal [Everypolitician::Popolo::Event.new(classification: 'legislative period',
+                                                     id:             'term/54',
+                                                     name:           '54th Parliament of the United Kingdom'),], subject.terms_added
+  end
 end

--- a/test/fixtures/after.json
+++ b/test/fixtures/after.json
@@ -20,5 +20,17 @@
     {
       "id": "47e60c56-a663-4cad-b8d8-b63309fdd7c4"
     }
+  ],
+  "events": [
+    {
+      "classification": "legislative period",
+      "id": "term/53",
+      "name": "53rd Parliament of the United Kingdom"
+    },
+    {
+      "classification": "legislative period",
+      "id": "term/54",
+      "name": "54th Parliament of the United Kingdom"
+    }
   ]
 }

--- a/test/fixtures/before.json
+++ b/test/fixtures/before.json
@@ -20,5 +20,17 @@
     {
       "id": "47c71c45-e37e-4936-ba3d-e4abee929da0"
     }
+  ],
+  "events": [
+    {
+      "classification": "legislative period",
+      "id": "term/52",
+      "name": "52nd Parliament of the United Kingdom"
+    },
+    {
+      "classification": "legislative period",
+      "id": "term/53",
+      "name": "53rd Parliament of the United Kingdom"
+    }
   ]
 }

--- a/test/review_changes_test.rb
+++ b/test/review_changes_test.rb
@@ -13,6 +13,18 @@ describe ReviewChanges do
             { id: 'abc', name: 'Reds' },
             { id: 'def', name: 'Greens' },
           ],
+          events:        [
+            {
+              classification: 'legislative period',
+              id:             'term/52',
+              name:           '52nd Parliament of the United Kingdom',
+            },
+            {
+              classification: 'legislative period',
+              id:             'term/53',
+              name:           '53rd Parliament of the United Kingdom',
+            },
+          ],
         }.to_json,
         after:  {
           persons:       [
@@ -22,6 +34,18 @@ describe ReviewChanges do
           organizations: [
             { id: 'abc', name: 'Reds' },
             { id: 'ghi', name: 'Blues' },
+          ],
+          events:        [
+            {
+              classification: 'legislative period',
+              id:             'term/53',
+              name:           '53rd Parliament of the United Kingdom',
+            },
+            {
+              classification: 'legislative period',
+              id:             'term/54',
+              name:           '54th Parliament of the United Kingdom',
+            },
           ],
         }.to_json,
         path:   'foo/bar.json',
@@ -38,5 +62,7 @@ describe ReviewChanges do
     assert comment.include?('- `456` - Alice')
     assert comment.include?('- `def` - Greens')
     assert comment.include?('- `ghi` - Blues')
+    assert comment.include?('- `term/54` - 54th Parliament of the United Kingdom')
+    assert comment.include?('- `term/52` - 52nd Parliament of the United Kingdom')
   end
 end


### PR DESCRIPTION
Adds a list of any added/removed terms from the summary.

Example output:
Summary of changes in `foo/bar.json`:
## People
### Added

No people added
### Removed

No people removed
### Name Changes

No name changes
### Additional Name Changes

No name changes
### Wikidata Changes

No changes
## Organizations
### Added

No organizations added
### Removed

No organizations removed
## Terms
### Added
- `term/42`
- `term/88`
### Removed
- `term/101`

Closes https://github.com/everypolitician/everypolitician/issues/368
