### PR TITLE
Report added/removed elections in bot PR Summary

### DIFF
--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -97,4 +97,26 @@ No terms added
 No terms removed
 <% end %>
 
+## Elections
+
+### Added
+
+<% if file.elections_added.any? %>
+<% file.elections_added.each do |election| %>
+- `<%= election.id %>` - <%= election.name %>
+<% end %>
+<% else %>
+No elections added
+<% end %>
+
+### Removed
+
+<% if file.elections_removed.any? %>
+<% file.elections_removed.each do |election| %>
+- `<%= election.id %>` - <%= election.name %>
+<% end %>
+<% else %>
+No elections removed
+<% end %>
+
 <% end %>

--- a/lib/compare_popolo.rb
+++ b/lib/compare_popolo.rb
@@ -52,4 +52,12 @@ class ComparePopolo
   def terms_removed
     Report::Terms.new(before, after).removed
   end
+
+  def elections_added
+    Report::Elections.new(before, after).added
+  end
+
+  def elections_removed
+    Report::Elections.new(before, after).removed
+  end
 end

--- a/lib/report/elections.rb
+++ b/lib/report/elections.rb
@@ -1,0 +1,17 @@
+class Report
+  class Elections < Base
+    def elections(events)
+      events.select do |event|
+        event if event.document[:classification] == 'general election'
+      end
+    end
+
+    def added
+      elections(after.events - before.events)
+    end
+
+    def removed
+      elections(before.events - after.events)
+    end
+  end
+end

--- a/test/compare_popolo_test.rb
+++ b/test/compare_popolo_test.rb
@@ -35,9 +35,21 @@ describe ComparePopolo do
                                                      name:           '52nd Parliament of the United Kingdom'),], subject.terms_removed
   end
 
-  it 'should return the full popolo for add terms' do
+  it 'should return the full popolo for added terms' do
     assert_equal [Everypolitician::Popolo::Event.new(classification: 'legislative period',
                                                      id:             'term/54',
                                                      name:           '54th Parliament of the United Kingdom'),], subject.terms_added
+  end
+
+  it 'should return the full popolo for removed elections' do
+    assert_equal [Everypolitician::Popolo::Event.new(classification: 'general election',
+                                                     id:             'Q20311786',
+                                                     name:           'Abkhazian parliamentary election, 1991'),], subject.elections_removed
+  end
+
+  it 'should return the full popolo for added elections' do
+    assert_equal [Everypolitician::Popolo::Event.new(classification: 'general election',
+                                                     id:             'Q16960120',
+                                                     name:           'Abkhazian parliamentary election, 2002'),], subject.elections_added
   end
 end

--- a/test/fixtures/after.json
+++ b/test/fixtures/after.json
@@ -31,6 +31,20 @@
       "classification": "legislative period",
       "id": "term/54",
       "name": "54th Parliament of the United Kingdom"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1996-11-23",
+      "id": "Q4668016",
+      "name": "Abkhazian parliamentary election, 1996",
+      "start_date": "1996-11-23"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2002-03-02",
+      "id": "Q16960120",
+      "name": "Abkhazian parliamentary election, 2002",
+      "start_date": "2002-03-02"
     }
   ]
 }

--- a/test/fixtures/before.json
+++ b/test/fixtures/before.json
@@ -31,6 +31,20 @@
       "classification": "legislative period",
       "id": "term/53",
       "name": "53rd Parliament of the United Kingdom"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1991",
+      "id": "Q20311786",
+      "name": "Abkhazian parliamentary election, 1991",
+      "start_date": "1991"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1996-11-23",
+      "id": "Q4668016",
+      "name": "Abkhazian parliamentary election, 1996",
+      "start_date": "1996-11-23"
     }
   ]
 }

--- a/test/review_changes_test.rb
+++ b/test/review_changes_test.rb
@@ -24,6 +24,20 @@ describe ReviewChanges do
               id:             'term/53',
               name:           '53rd Parliament of the United Kingdom',
             },
+            {
+              classification: 'general election',
+              end_date:       '1991',
+              id:             'Q20311786',
+              name:           'Abkhazian parliamentary election, 1991',
+              start_date:     '1991',
+            },
+            {
+              classification: 'general election',
+              end_date:       '1996-11-23',
+              id:             'Q4668016',
+              name:           'Abkhazian parliamentary election, 1996',
+              start_date:     '1996-11-23',
+            },
           ],
         }.to_json,
         after:  {
@@ -46,6 +60,20 @@ describe ReviewChanges do
               id:             'term/54',
               name:           '54th Parliament of the United Kingdom',
             },
+            {
+              classification: 'general election',
+              end_date:       '1996-11-23',
+              id:             'Q4668016',
+              name:           'Abkhazian parliamentary election, 1996',
+              start_date:     '1996-11-23',
+            },
+            {
+              classification: 'general election',
+              end_date:       '2002-03-02',
+              id:             'Q16960120',
+              name:           'Abkhazian parliamentary election, 2002',
+              start_date:     '2002-03-02',
+            },
           ],
         }.to_json,
         path:   'foo/bar.json',
@@ -64,5 +92,7 @@ describe ReviewChanges do
     assert comment.include?('- `ghi` - Blues')
     assert comment.include?('- `term/54` - 54th Parliament of the United Kingdom')
     assert comment.include?('- `term/52` - 52nd Parliament of the United Kingdom')
+    assert comment.include?('- `Q16960120` - Abkhazian parliamentary election, 2002')
+    assert comment.include?('- `Q20311786` - Abkhazian parliamentary election, 1991')
   end
 end


### PR DESCRIPTION
Adds a list of added/removed elections in summariser comment.
(Branched from https://github.com/everypolitician/review_changes/pull/28)

Example output: 
## Elections
### Added
- `Q3000` - Argentine general election, 1924
- `Q4000` - Argentine general election, 1925
- `Q5000` - Argentine general election, 1926
### Removed
- `Q2000` - Argentine general election, 1923

Closes https://github.com/everypolitician/everypolitician/issues/477
