### PR TITLE
Be explicit when there are no changes to review

### DIFF
--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -1,3 +1,6 @@
+<% if popolo_files.empty? %>
+No Popolo files were changed in this pull request.
+<% else %>
 <% popolo_files.each do |file| %>
 Summary of changes in `<%= file.path %>`:
 
@@ -119,4 +122,5 @@ No elections added
 No elections removed
 <% end %>
 
+<% end %>
 <% end %>


### PR DESCRIPTION
If there are no popolo files changed in the pull request then be explicit about that rather than just failing silently.
