### PR TITLE
Better error reporting when commenting fails

### DIFF
--- a/lib/pull_request_review.rb
+++ b/lib/pull_request_review.rb
@@ -18,8 +18,8 @@ class PullRequestReview
         pull_request_number,
         ReviewChanges.new(popolo_before_after).to_html
       )
-    rescue Octokit::UnprocessableEntity
-      warn "No changes detected on pull request #{pull_request_number}"
+    rescue Octokit::UnprocessableEntity => e
+      warn "Unable to review pull request #{pull_request_number}: #{e.message}"
     end
   end
 


### PR DESCRIPTION
When leaving a comment on GitHub fails it's useful to know exactly why.
This change rescues the exception and prints out the message along with
the pull request number that was being processed.
